### PR TITLE
chore: add instructions how to contribute

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+DFINITY.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing
+
+Thank you for your interest in contributing to this repo.
+By participating in this project, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+As a member of the community, you are invited and encouraged to contribute by submitting issues, offering suggestions for improvements, adding review comments to existing pull requests, or creating new pull requests to fix issues.
+
+All contributions to DFINITY documentation and the developer community are respected and appreciated.
+Your participation is an important factor in the success of the Internet Computer.
+
+## Contents of this repository
+
+This repository contains source code for the canister interface description language—often referred to as Candid or IDL. Candid provides a common language for specifying the signature of a canister service and interacting with canisters running on the
+Internet Computer.
+
+## Before you contribute
+
+Before contributing, please take a few minutes to review these contributor guidelines.
+The contributor guidelines are intended to make the contribution process easy and effective for everyone involved in addressing your issue, assessing changes, and finalizing your pull requests.
+
+Before contributing, consider the following:
+
+- If you want to report an issue, click **Issues**.
+
+- If you have more general questions related to Candid and its use, post a message to the [community forum](https://forum.dfinity.org/) or submit a [support request](mailto://support@dfinity.org).
+
+- If you are reporting a bug, provide as much information about the problem as possible.
+
+- If you want to contribute directly to this repository, typical fixes might include any of the following:
+
+    - Fixes to resolve bugs or documentation errors
+    - Code improvements
+    - Feature requests
+
+    Note that any contribution to this repository must be submitted in the form of a **pull request**.
+
+- If you are creating a pull request, be sure that the pull request only implements one fix or suggestion.
+
+If you are new to working with GitHub repositories and creating pull requests, consider exploring [First Contributions](https://github.com/firstcontributions/first-contributions) or [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
+
+# How to make a contribution
+
+Depending on the type of contribution you want to make, you might follow different workflows.
+
+This section describes the most common workflow scenarios:
+
+- Reporting an issue
+- Submitting a pull request
+
+### Reporting an issue
+
+To open a new issue:
+
+1. Click **Issues**.
+
+1. Click **New Issue**.
+
+1. Click **Open a blank issue**.
+
+1. Type a title and description, then click **Submit new issue**.
+
+    Be as clear and descriptive as possible.
+
+    For any problem, describe it in detail, including details about the crate, the version of the code you are using, the results you expected, and how the actual results differed from your expectations.
+
+### Submitting a pull request
+
+If you want to submit a pull request to fix an issue or add a feature, here's a summary of what you need to do:
+
+1. Make sure you have a GitHub account, an internet connection, and access to a terminal shell or GitHub Desktop application for running commands.
+
+1. Navigate to the DFINITY public repository in a web browser.
+
+1. Click **Fork** to create a copy of the repository associated with the issue you want to address under your GitHub account or organization name.
+
+1. Clone the repository to your local machine.
+
+1. Create a new branch for your fix by running a command similar to the following:
+
+    ```bash
+    git checkout -b my-branch-name-here
+    ```
+
+1. Open the file you want to fix in a text editor and make the appropriate changes for the issue you are trying to address.
+
+1. Add the file contents of the changed files to the index `git` uses to manage the state of the project by running a command similar to the following:
+
+    ```bash
+    git add path-to-changed-file
+    ```
+1. Commit your changes to store the contents you added to the index along with a descriptive message by running a command similar to the following:
+
+    ```bash
+    git commit -m "Description of the fix being committed."
+    ```
+
+1. Push the changes to the remote repository by running a command similar to the following:
+
+    ```bash
+    git push origin my-branch-name-here
+    ```
+
+1. Create a new pull request for the branch you pushed to the upstream GitHub repository.
+
+    Provide a title that includes a short description of the changes made.
+
+1. Wait for the pull request to be reviewed.
+
+1. Make changes to the pull request, if requested.
+
+1. Celebrate your success after your pull request is merged!


### PR DESCRIPTION
This is needed for open-sourcing.

Shamelessly frobbed from https://github.com/dfinity/ic-docutrack/blob/main/.github/CONTRIBUTING.md and https://github.com/dfinity/ic-docutrack/blob/main/.github/CODE_OF_CONDUCT.md.